### PR TITLE
Don’t extend lint configuration from sagui

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,14 @@
 {
-  "extends": "./node_modules/sagui/.eslintrc"
+  "extends": [
+    "eslint-config-standard",
+    "eslint-config-standard-jsx",
+  ],
+
+  "env": {
+    "jasmine": true
+  },
+
+  "globals": {
+    "sinon": false
+  }
 }


### PR DESCRIPTION
Sagui is not available at CodeClimate setup, for example.

Can I run npm install at CodeClimate?
